### PR TITLE
Make the game installable on Android - add service worker + manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 	<meta charset="UTF-8" />
 	<title>SNAKISMS</title>
 	<link rel="manifest" href="manifest.json">
+	<meta name="theme-color" content="#000000">
 
 	<script src="js/phaser.min.js"></script>
 	<script src="js/swipe.js"></script>

--- a/index.html
+++ b/index.html
@@ -87,8 +87,17 @@ body {
 
 	};
 
-	</script>
+	if('serviceWorker' in navigator) {
+		navigator.serviceWorker.register('./sw.js')
+			.then(function(registration) {
+				console.log('Service Worker Registered');
+			});
 
+		navigator.serviceWorker.ready.then(function(registration) {
+			console.log('Service Worker Ready');
+		});
+	}
+	</script>
 
 	<script>
 	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
 	<meta charset="UTF-8" />
 	<title>SNAKISMS</title>
+	<link rel="manifest" href="manifest.json">
 
 	<script src="js/phaser.min.js"></script>
 	<script src="js/swipe.js"></script>

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "SNAKISMS",
+  "short_name": "SNAKISMS",
+  "description": "Life is meaningless! Maybe you need some kind of ism to attempt to ward off the inevitable and unavoidable despair! Here, have some isms made of snakes! Life is still meaningless but now you have a bunch of snakes as well! Thank me later!",
+  "start_url": "index.html",
+  "theme_color": "#000000",
+  "background_color": "#000000",
+  "icons": [
+    {
+        "src": "press/images/SNAKISMS.png",
+        "type": "image/png",
+        "sizes": "300x300"
+    }
+  ]
+}

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
   "start_url": "index.html",
   "theme_color": "#000000",
   "background_color": "#000000",
+  "display": "standalone",
   "icons": [
     {
         "src": "press/images/SNAKISMS.png",

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,74 @@
+self.addEventListener('install', e => {
+  e.waitUntil(
+    caches.open('SNAKISMS').then(cache => {
+      return cache.addAll([
+        '/',
+        'js/phaser.min.js',
+        'js/swipe.js',
+        'Boot.js',
+        'Preloader.js',
+        'Menu.js',
+        'snakes/Snake.js',
+        'snakes/Anthropomorphism.js',
+        'snakes/Apocalypticism.js',
+        'snakes/Asceticism.js',
+        'snakes/Capitalism.js',
+        'snakes/Casualism.js',
+        'snakes/Conservatism.js',
+        'snakes/Determinism.js',
+        'snakes/Dualism.js',
+        'snakes/Existentialism.js',
+        'snakes/Holism.js',
+        'snakes/Idealism.js',
+        'snakes/Monism.js',
+        'snakes/Narcissism.js',
+        'snakes/Nihilism.js',
+        'snakes/Optimism.js',
+        'snakes/Pessimism.js',
+        'snakes/Positivism.js',
+        'snakes/PostApocalypticism.js',
+        'snakes/Romanticism.js',
+        'snakes/Stoicism.js',
+        'snakes/Utilitarianism.js',
+        // Save Fonts
+        'assets/fonts/atari.png',
+        'assets/fonts/atari.xml',
+        // Save Images
+        'assets/images/apple.png',
+        'assets/images/black.png',
+        'assets/images/head.png',
+        'assets/images/wall.png',
+        'assets/images/postapocalyptic01.png',
+        'assets/images/postapocalyptic02.png',
+        'assets/images/postapocalyptic03.png',
+        'assets/images/postapocalyptic04.png',
+        'assets/images/postapocalyptic05.png',
+        // Save sounds
+        'assets/sounds/apple.mp3',
+        'assets/sounds/apple.ogg',
+        'assets/sounds/apple.wav',
+        'assets/sounds/hit.mp3',
+        'assets/sounds/hit.ogg',
+        'assets/sounds/hit.wav',
+        'assets/sounds/move.mp3',
+        'assets/sounds/move.ogg',
+        'assets/sounds/move.wav',
+        'assets/sounds/romanticmusic.mp3',
+        'assets/sounds/romanticmusic.ogg'
+      ])
+      .then(() => self.skipWaiting());
+    })
+  )
+});
+
+self.addEventListener('activate',  event => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
Hello,

Firstly awesome game! I came across it on hacker news.

Secondly sorry for the blind pull request please feel free to discard this (I should have opened an issue first), but I want to show how easy it is to make this game installable on different platforms with minimal effort. Also sorry if you already know this in advance.

I've added a [Web App Manifest](https://www.w3.org/TR/appmanifest/) that describes how a web app or game should appear on the users system. I thought that users might like to launch the game in near full screen mode if they have decided to install it.

I've also added a [Service Worker](https://developers.google.com/web/fundamentals/getting-started/primers/service-workers) (you could add an AppCache for Safari support). The ServiceWorker is what let's you install the assets for your game and let it work offline, it is also one of the requirements to get an install button on the page.

I sneakly added a `<meta>` theme-color to make the menu bar the same colour as your screen.

The fork of this is running at https://paulkinlan.github.io/SNAKISMS/ if you want to test it out.  But I've also included some screenshots too to show what it looks like.

![screenshot_20170307-114500](https://cloud.githubusercontent.com/assets/45510/23655404/c257d5fc-032c-11e7-8fd2-7b2c379cd9f8.png)
![screenshot_20170307-114522](https://cloud.githubusercontent.com/assets/45510/23655406/c3fc7944-032c-11e7-978e-d0c7cc4a5521.png)
![screenshot_20170307-115223](https://cloud.githubusercontent.com/assets/45510/23655408/c6186e18-032c-11e7-8482-b1e37c01fd7d.png)
![screenshot_20170307-114549](https://cloud.githubusercontent.com/assets/45510/23655410/c7a2b2f2-032c-11e7-983b-29339921e272.png)
![screenshot_20170307-114553](https://cloud.githubusercontent.com/assets/45510/23655412/cbe23e64-032c-11e7-860b-c15fc7a79903.png)
